### PR TITLE
Do not define default mappings in select mode

### DIFF
--- a/plugin/dentures.vim
+++ b/plugin/dentures.vim
@@ -134,7 +134,7 @@ function! s:map (name, denture)
     exe "ono <silent> <Plug>(" . a:name . ") :<C-U>call <SID>select('" . a:denture . "', line('.'), v:operator == 'c' ? 'v' : 'V', v:operator)<CR>"
     exe "vno <silent> <Plug>(" . a:name . ") :<C-U>call <SID>select('" . a:denture . "', line('.'), visualmode(), '')<CR>"
     exe "omap <silent>" a:denture "<Plug>(" . a:name . ")"
-    exe "vmap <silent>" a:denture "<Plug>(" . a:name . ")"
+    exe "xmap <silent>" a:denture "<Plug>(" . a:name . ")"
 endfunction
 
 call s:map('InnerDenture', 'ii')


### PR DESCRIPTION
```
,----[ :help Select-mode-mapping ]----
| Users will expect printable characters to replace the selected area.
| Therefore avoid mapping printable characters in Select mode.
`----
```

Therefore, use `:xmap` instead of `:vmap` for the default mappings (the `<Plug>` mappings are fine for both modes).
