### PR TITLE
Allow re-using text object with '.'

### DIFF
--- a/autoload/dentures.vim
+++ b/autoload/dentures.vim
@@ -84,5 +84,9 @@ function! dentures#select (line, space, more, mode)
     endif
 
     "" Select the denture
-    return ":\<C-u>normal! ".l:fline."gg^\<C-v>".a:mode.l:lline."gg$\<CR>"
+    if a:mode == 'operator'
+      execute "normal! ".l:fline."ggV".l:lline."gg"
+    else
+      return ":\<C-u>normal! ".l:fline."gg^\<C-v>".a:mode.l:lline."gg$\<CR>"
+    endif
 endfunction

--- a/plugin/dentures.vim
+++ b/plugin/dentures.vim
@@ -5,7 +5,7 @@ vnoremap <silent><expr> <Plug>(OuterDenture) dentures#select(line('.'), 1, 0, mo
 vnoremap <silent><expr> <Plug>(OuterDENTURE) dentures#select(line('.'), 1, 1, mode())
 
 "" Operator plugin mappings
-onoremap <silent><expr> <Plug>(InnerDenture) dentures#select(line('.'), 0, 0, 'V')
-onoremap <silent><expr> <Plug>(InnerDENTURE) dentures#select(line('.'), 0, 1, 'V')
-onoremap <silent><expr> <Plug>(OuterDenture) dentures#select(line('.'), 1, 0, 'V')
-onoremap <silent><expr> <Plug>(OuterDENTURE) dentures#select(line('.'), 1, 1, 'V')
+onoremap <silent> <Plug>(InnerDenture) :<C-u>call dentures#select(line('.'), 0, 0, 'operator')<CR>
+onoremap <silent> <Plug>(InnerDENTURE) :<C-u>call dentures#select(line('.'), 0, 1, 'operator')<CR>
+onoremap <silent> <Plug>(OuterDenture) :<C-u>call dentures#select(line('.'), 1, 0, 'operator')<CR>
+onoremap <silent> <Plug>(OuterDENTURE) :<C-u>call dentures#select(line('.'), 1, 1, 'operator')<CR>


### PR DESCRIPTION
Hi there, I came across this problem and think I have a reasonable solution.

## Problem:
Given the file
`test.txt`
```
First line of test.txt
    Some filler words
    Hello thereh
    third line
Should remain
    Goes away
    Some lines
    Should go away
Should remain
```

Put the cursor on the third line and press `dii`, it removes the indentation as expected.
```
First line of test.txt
Should remain
    Goes away
    Some lines
    Should go away
Should remain
```

Now move to the third line again, and press `.`, this removes the same lines in the buffer, not the current indentation object
```
First line of test.txt
    Should go away
Should remain
```

In contrast, pressing `dii` in that position leaves the text
```
First line of test.txt
Should remain
Should remain
```

## Solution
In the operator mapping, directly call `dentures#select` by using `:call dentures#select`, this fixes the above problem.

It appears to work for me, I hope I haven't missed anything